### PR TITLE
Solves for two-letter words using "y" as a vowel

### DIFF
--- a/models/piglatinizer.rb
+++ b/models/piglatinizer.rb
@@ -18,7 +18,7 @@ class PigLatinizer
     elsif consonant?(word[0]) && consonant?(word[1]) && consonant?(word[2])
       word = word.slice(3..-1) + word.slice(0,3)
     # word starts with 2 consonants
-    elsif consonant?(word[0]) && consonant?(word[1])
+    elsif word[2] != nil && consonant?(word[0]) && consonant?(word[1])
       word = word.slice(2..-1) + word.slice(0,2)
     # word starts with 1 consonant
     else


### PR DESCRIPTION
Previous solution failed on line 21, where words like "by" and "my" use "y" as a vowel. New commit uses `word[2] != nil` in 2-consonant branch of the conditional to check if the word is at least three letters. 

A two-letter word will either (a) already end or start in a vowel or (b) end with 'y'. Since 'y' isn't treated as vowel, the current solution uses the third branch of the conditional --- as if there's two consonants. However, there's no `word[2]` to slice, since it's only a two-letter word. Adding the check for a third letter ensures that all two-letter words are covered by the solution, since it will skip to the `else` branch of the conditional.